### PR TITLE
Remove analyzer dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,6 @@ dependencies:
   source_gen: ^1.0.1
   build: ^2.0.2
   code_builder: ^4.0.0
-  analyzer: ^1.7.1
   glob: ^2.0.1
   # TODO point to 1.0.2 as soon as it is merged
   flutter_translate_annotations:


### PR DESCRIPTION
Wir müssen bei uns den analyzer overriden, was zu einer Warning führt. Lokal kann ich das auch bauen, wenn ich die Dep komplett raus nehme, statt die jetzt hoch zu setzen.